### PR TITLE
Fix: Handle null return from getCurrentState() in BuildCurrentStateEntries

### DIFF
--- a/Wazebar.js
+++ b/Wazebar.js
@@ -141,7 +141,7 @@
       return null; // Handle the case where no top state is available
     }
     return topState.name;
-  }  
+  }
 
   function updateCurrentStateEntries() {
     const topState = wmeSDK.DataModel.States.getTopState();
@@ -406,7 +406,7 @@
     var count = 0;
     var jdat, dat1;
 
-    if (debug) console.log(`${SCRIPT_NAME}: CheckUnreadTopics() called for `, path , parentID , spanID);
+    if (debug) console.log(`${SCRIPT_NAME}: CheckUnreadTopics() called for `, path, parentID, spanID);
 
     $.get(path, function (page) {
       const jpattern = /data-preloaded=\"(.*)\">/;
@@ -572,19 +572,21 @@
   }
 
   function BuildCurrentStateEntries() {
-    const topCountry = wmeSDK.DataModel.Countries.getTopCountry();
-    const topCountryId = topCountry ? topCountry.id : null;
-    
     var currentState = "";
 
-    if (!forumPage && topCountryId === 235) { 
-      // Only proceed if the top country is the US
-      var currState = getCurrentState();
-      if (!currState || !States[currState]) {
-        return currentState; // Return an empty string if currState or its corresponding States entry is invalid.
+    if (!forumPage) {
+      const topCountry = wmeSDK.DataModel.Countries.getTopCountry();
+      const topCountryId = topCountry ? topCountry.id : null;
+
+      if (topCountryId === 235) {
+        // Only proceed if the top country is the US
+        var currState = getCurrentState();
+        if (!currState || !States[currState]) {
+          return currentState; // Return an empty string if currState or its corresponding States entry is invalid.
+        }
+        currentState += '<div class="WazeBarText WazeBarCurrState" id="' + currState.replace(" ", "_") + 'ForumCurrState"><a href="' + States[currState].forum.replace("https://www.waze.com", location.origin) + '" ' + LoadNewTab() + ">" + States[currState].abbr + "</a></div>";
+        currentState += '<div class="WazeBarText WazeBarCurrState"><a href="' + States[currState].wiki + '" target="_blank">' + States[currState].abbr + " Wiki</a></div>";
       }
-      currentState += '<div class="WazeBarText WazeBarCurrState" id="' + currState.replace(" ", "_") + 'ForumCurrState"><a href="' + States[currState].forum.replace("https://www.waze.com", location.origin) + '" ' + LoadNewTab() + ">" + States[currState].abbr + "</a></div>";
-      currentState += '<div class="WazeBarText WazeBarCurrState"><a href="' + States[currState].wiki + '" target="_blank">' + States[currState].abbr + " Wiki</a></div>";
     }
     return currentState;
   }

--- a/Wazebar.js
+++ b/Wazebar.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         WME Wazebar
 // @namespace    https://greasyfork.org/users/30701-justins83-waze
-// @version      2025.01.10.01
+// @version      2025.02.08.00
 // @description  Displays a bar at the top of the editor that displays inbox, forum & wiki links
 // @author       JustinS83
 // @include      https://beta.waze.com/*
@@ -141,7 +141,7 @@
       return null; // Handle the case where no top state is available
     }
     return topState.name;
-  }
+  }  
 
   function updateCurrentStateEntries() {
     const topState = wmeSDK.DataModel.States.getTopState();
@@ -572,10 +572,17 @@
   }
 
   function BuildCurrentStateEntries() {
+    const topCountry = wmeSDK.DataModel.Countries.getTopCountry();
+    const topCountryId = topCountry ? topCountry.id : null;
+    
     var currentState = "";
-    if (!forumPage && typeof W.model.countries.objects[235] !== "undefined") {
-      //only do for the US
+
+    if (!forumPage && topCountryId === 235) { 
+      // Only proceed if the top country is the US
       var currState = getCurrentState();
+      if (!currState || !States[currState]) {
+        return currentState; // Return an empty string if currState or its corresponding States entry is invalid.
+      }
       currentState += '<div class="WazeBarText WazeBarCurrState" id="' + currState.replace(" ", "_") + 'ForumCurrState"><a href="' + States[currState].forum.replace("https://www.waze.com", location.origin) + '" ' + LoadNewTab() + ">" + States[currState].abbr + "</a></div>";
       currentState += '<div class="WazeBarText WazeBarCurrState"><a href="' + States[currState].wiki + '" target="_blank">' + States[currState].abbr + " Wiki</a></div>";
     }


### PR DESCRIPTION
- Updated BuildCurrentStateEntries function to handle cases where getCurrentState() returns null.
- Added checks to ensure currState is valid before attempting to use it for building the WazeBar current state links.
- Replaced the previous country check with a more robust mechanism using wmeSDK.DataModel.Countries.getTopCountry() to identify the top country as the US.
- Prevented Javascript errors by returning an empty string if currState is null or not found in the States object.